### PR TITLE
Updated package to use Omnipay v3 library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,12 @@
         "psr-4": { "Omnipay\\Postfinance\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "^3.0",
+        "league/omnipay": "^3",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "^3.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>


### PR DESCRIPTION
This is a PR to make the package compatible with V3 of the Omnipay library, which is required for Symfony 3+ and associated components.